### PR TITLE
TAS-3685

### DIFF
--- a/src/modules/Projects/containers/CommentSection/index.tsx
+++ b/src/modules/Projects/containers/CommentSection/index.tsx
@@ -83,7 +83,7 @@ const CommentSection = ({ projectId }: { projectId: string }) => {
                 setReplyText(value);
                 setError(null);
               }}
-              onEmojiSelect={emoji => setCommentText(prev => prev + emoji)}
+              onEmojiSelect={emoji => setReplyText(prev => prev + emoji)}
               onSend={handleSendReply}
               disabled={isSubmitting}
             />


### PR DESCRIPTION
fixed the emoji picker bug on commenting section, when choosing the emoji on the reply text input, the emoji was getting typed in the original commenting box.